### PR TITLE
Fixed overflow bug when loading large PLY files

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -96,7 +96,7 @@ bool
 pcl::PLYReader::endHeaderCallback ()
 {
   cloud_->data.resize (static_cast<size_t>(cloud_->point_step) * cloud_->width * cloud_->height);
-  return (cloud_->data.size () == cloud_->point_step * cloud_->width * cloud_->height);
+  return (cloud_->data.size () == static_cast<size_t>(cloud_->point_step) * cloud_->width * cloud_->height);
 }
 
 template<typename Scalar> void
@@ -435,7 +435,7 @@ pcl::PLYReader::vertexEndCallback ()
   {
     cloud_->point_step = vertex_offset_before_;
     cloud_->row_step = cloud_->point_step * cloud_->width;
-    cloud_->data.resize (cloud_->point_step * cloud_->width * cloud_->height);
+    cloud_->data.resize (static_cast<size_t>(cloud_->point_step) * cloud_->width * cloud_->height);
   }
   ++vertex_count_;
 }


### PR DESCRIPTION
This problem was partially fixed in https://github.com/PointCloudLibrary/pcl/pull/2161, but a few places remained where the overflow still occurred, causing the point cloud to be initialized to all zeros.

cc @dakotabenjamin 